### PR TITLE
Update + Fix TerminalEmulator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "VtNetCore.Avalonia"]
 	path = VtNetCore.Avalonia
 	url = https://github.com/HendrikMennen/VtNetCore.Avalonia.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "VtNetCore.Avalonia"]
 	path = VtNetCore.Avalonia
-	url = https://github.com/VitalElement/VtNetCore.Avalonia.git
+	url = https://github.com/HendrikMennen/VtNetCore.Avalonia.git

--- a/src/AvalonStudio.TerminalEmulator/App.xaml
+++ b/src/AvalonStudio.TerminalEmulator/App.xaml
@@ -1,6 +1,5 @@
 <Application x:Class="AvalonStudio.TerminalEmulator.App"
              xmlns="https://github.com/avaloniaui"
-              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:AvalonStudio.TerminalEmulator">
   <Application.DataTemplates>
@@ -10,5 +9,6 @@
   <Application.Styles>
     <StyleInclude Source="resm:Avalonia.Themes.Default.DefaultTheme.xaml?assembly=Avalonia.Themes.Default"/>
     <StyleInclude Source="resm:Avalonia.Themes.Default.Accents.BaseLight.xaml?assembly=Avalonia.Themes.Default"/>
+    <StyleInclude Source="avares://VtNetCore.Avalonia/VirtualTerminalControl.xaml"/>
   </Application.Styles>
 </Application>

--- a/src/AvalonStudio.TerminalEmulator/App.xaml.cs
+++ b/src/AvalonStudio.TerminalEmulator/App.xaml.cs
@@ -1,5 +1,7 @@
 using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using AvalonStudio.TerminalEmulator.Views;
 
 namespace AvalonStudio.TerminalEmulator
 {
@@ -9,5 +11,15 @@ namespace AvalonStudio.TerminalEmulator
         {
             AvaloniaXamlLoader.Load(this);
         }
-   }
+
+        public override void OnFrameworkInitializationCompleted()
+        {
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                desktop.MainWindow = new MainWindow();
+            }
+
+            base.OnFrameworkInitializationCompleted();
+        }
+    }
 }

--- a/src/AvalonStudio.TerminalEmulator/AvalonStudio.TerminalEmulator.csproj
+++ b/src/AvalonStudio.TerminalEmulator/AvalonStudio.TerminalEmulator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">

--- a/src/AvalonStudio.TerminalEmulator/AvalonStudio.TerminalEmulator.csproj
+++ b/src/AvalonStudio.TerminalEmulator/AvalonStudio.TerminalEmulator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">
@@ -13,13 +13,13 @@
     <EmbeddedResource Include="Assets\*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.7.1-cibuild0001742-beta" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.7.1-cibuild0001742-beta" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.10" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.10" />
     <PackageReference Include="NSubsys" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ReactiveUI" Version="9.12.1" />
+    <PackageReference Include="ReactiveUI" Version="11.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\VtNetCore.Avalonia\VtNetCore.Avalonia\VtNetCore.Avalonia.csproj" />

--- a/src/AvalonStudio.TerminalEmulator/AvalonStudio.TerminalEmulator.csproj
+++ b/src/AvalonStudio.TerminalEmulator/AvalonStudio.TerminalEmulator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">

--- a/src/AvalonStudio.TerminalEmulator/Program.cs
+++ b/src/AvalonStudio.TerminalEmulator/Program.cs
@@ -9,16 +9,16 @@ namespace AvalonStudio.TerminalEmulator
 {
     class Program
     {
-        static void Main(string[] args)
-        {
-            UnixPsuedoTerminal.Trampoline(args);
-            BuildAvaloniaApp().Start<MainWindow>(() => new TerminalViewModel());
-        }
+        // Initialization code. Don't use any Avalonia, third-party APIs or any
+        // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+        // yet and stuff might break.
+        public static void Main(string[] args) => BuildAvaloniaApp()
+            .StartWithClassicDesktopLifetime(args);
 
+        // Avalonia configuration, don't remove; also used by visual designer.
         public static AppBuilder BuildAvaloniaApp()
             => AppBuilder.Configure<App>()
                 .UsePlatformDetect()
-                .UseReactiveUI()
                 .LogToDebug();
     }
 }

--- a/src/AvalonStudio.TerminalEmulator/Program.cs
+++ b/src/AvalonStudio.TerminalEmulator/Program.cs
@@ -12,8 +12,12 @@ namespace AvalonStudio.TerminalEmulator
         // Initialization code. Don't use any Avalonia, third-party APIs or any
         // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
         // yet and stuff might break.
-        public static void Main(string[] args) => BuildAvaloniaApp()
-            .StartWithClassicDesktopLifetime(args);
+        public static void Main(string[] args)
+        {
+            UnixPsuedoTerminal.Trampoline(args);
+
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        }
 
         // Avalonia configuration, don't remove; also used by visual designer.
         public static AppBuilder BuildAvaloniaApp()

--- a/src/AvalonStudio.TerminalEmulator/Program.cs
+++ b/src/AvalonStudio.TerminalEmulator/Program.cs
@@ -14,7 +14,7 @@ namespace AvalonStudio.TerminalEmulator
         // yet and stuff might break.
         public static void Main(string[] args)
         {
-            UnixPsuedoTerminal.Trampoline(args);
+            //UnixPsuedoTerminal.Trampoline(args);
 
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }

--- a/src/AvalonStudio.TerminalEmulator/Views/MainWindow.xaml
+++ b/src/AvalonStudio.TerminalEmulator/Views/MainWindow.xaml
@@ -1,13 +1,30 @@
-<Window x:Class="AvalonStudio.TerminalEmulator.MainWindow"
-             xmlns="https://github.com/avaloniaui"
-              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+<Window x:Class="AvalonStudio.TerminalEmulator.Views.MainWindow"
+        xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:AvalonStudio.TerminalEmulator.ViewModels;assembly=AvalonStudio.TerminalEmulator"
         xmlns:vt100="clr-namespace:VtNetCore.Avalonia;assembly=VtNetCore.Avalonia"
         Icon="resm:AvalonStudio.TerminalEmulator.Assets.avalonia-logo.ico"
-        Title="AvalonStudio.TerminalEmulator" Background="Black" MinHeight="600" MinWidth="800">
+        Title="AvalonStudio.TerminalEmulator" Background="White" MinHeight="600" MinWidth="800">
+  <Window.Styles>
+    <Style Selector="vt100|VirtualTerminalControl">
+      <Setter Property="Background" Value="{DynamicResource ThemeControlMidBrush}"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLightBrush}"/>
+      <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+      <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
+      <Setter Property="Focusable" Value="True" />
+      <Setter Property="Padding" Value="4"/>
+      <Setter Property="FontSize" Value="14" />
+      <Setter Property="FontWeight" Value="Thin" />
+      <Setter Property="Cursor" Value="IBeam" />
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Panel />
+        </ControlTemplate>
+      </Setter>
+    </Style>
+  </Window.Styles>
     <Panel>
-        <TextBlock Text="Terminal is not connected." VerticalAlignment="Center" HorizontalAlignment="Center" />        
-        <vt100:VirtualTerminalControl ActiveConnection="{Binding Connection}" IsVisible="{Binding TerminalVisible}" FontFamily="Consolas, Ubuntu, Monaco" Focusable="True" />
+        <TextBlock Text="Terminal is not connected." IsVisible="{Binding !TerminalVisible}" VerticalAlignment="Center" HorizontalAlignment="Center" />        
+        <vt100:VirtualTerminalControl Name="Terminal" Terminal="{Binding Terminal}" Connection="{Binding Connection}" IsVisible="{Binding TerminalVisible}" FontFamily="Consolas, Ubuntu, Monaco" Focusable="True" />
     </Panel>
 </Window>

--- a/src/AvalonStudio.TerminalEmulator/Views/MainWindow.xaml
+++ b/src/AvalonStudio.TerminalEmulator/Views/MainWindow.xaml
@@ -4,27 +4,9 @@
         xmlns:vm="clr-namespace:AvalonStudio.TerminalEmulator.ViewModels;assembly=AvalonStudio.TerminalEmulator"
         xmlns:vt100="clr-namespace:VtNetCore.Avalonia;assembly=VtNetCore.Avalonia"
         Icon="resm:AvalonStudio.TerminalEmulator.Assets.avalonia-logo.ico"
-        Title="AvalonStudio.TerminalEmulator" Background="White" MinHeight="600" MinWidth="800">
-  <Window.Styles>
-    <Style Selector="vt100|VirtualTerminalControl">
-      <Setter Property="Background" Value="{DynamicResource ThemeControlMidBrush}"/>
-      <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLightBrush}"/>
-      <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
-      <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
-      <Setter Property="Focusable" Value="True" />
-      <Setter Property="Padding" Value="4"/>
-      <Setter Property="FontSize" Value="14" />
-      <Setter Property="FontWeight" Value="Thin" />
-      <Setter Property="Cursor" Value="IBeam" />
-      <Setter Property="Template">
-        <ControlTemplate>
-          <Panel />
-        </ControlTemplate>
-      </Setter>
-    </Style>
-  </Window.Styles>
+        Title="AvalonStudio.TerminalEmulator" Background="White" Height="600" Width="800">
     <Panel>
         <TextBlock Text="Terminal is not connected." IsVisible="{Binding !TerminalVisible}" VerticalAlignment="Center" HorizontalAlignment="Center" />        
-        <vt100:VirtualTerminalControl Name="Terminal" Terminal="{Binding Terminal}" Connection="{Binding Connection}" IsVisible="{Binding TerminalVisible}" FontFamily="Consolas, Ubuntu, Monaco" Focusable="True" />
+        <vt100:VirtualTerminalControl TextPadding="5" Name="Terminal" Terminal="{Binding Terminal}" Connection="{Binding Connection}" IsVisible="{Binding TerminalVisible}" FontFamily="Consolas, Ubuntu, Monaco" Focusable="True" />
     </Panel>
 </Window>

--- a/src/AvalonStudio.TerminalEmulator/Views/MainWindow.xaml.cs
+++ b/src/AvalonStudio.TerminalEmulator/Views/MainWindow.xaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using AvalonStudio.TerminalEmulator.ViewModels;
+using VtNetCore.Avalonia;
 
 namespace AvalonStudio.TerminalEmulator.Views
 {
@@ -9,6 +11,8 @@ namespace AvalonStudio.TerminalEmulator.Views
         public MainWindow()
         {
             InitializeComponent();
+
+            DataContext = new TerminalViewModel();
         }
 
         private void InitializeComponent()

--- a/src/AvalonStudio.Terminals/ProcessConnection.cs
+++ b/src/AvalonStudio.Terminals/ProcessConnection.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reactive.Concurrency;
 using System.Threading;
 using System.Threading.Tasks;
 using VtNetCore.Avalonia;

--- a/src/AvalonStudio.Terminals/Unix/Native.cs
+++ b/src/AvalonStudio.Terminals/Unix/Native.cs
@@ -123,9 +123,12 @@ namespace AvalonStudio.Terminals.Unix
         public static NativeDelegates.posix_spawnattr_init posix_spawnattr_init = NativeDelegates.GetProc<NativeDelegates.posix_spawnattr_init>();
         public static NativeDelegates.posix_spawnp posix_spawnp = NativeDelegates.GetProc<NativeDelegates.posix_spawnp>();
         public static NativeDelegates.dup dup = NativeDelegates.GetProc<NativeDelegates.dup>();
+        public static NativeDelegates.dup2 dup2 = NativeDelegates.GetProc<NativeDelegates.dup2>();
         public static NativeDelegates.setsid setsid = NativeDelegates.GetProc<NativeDelegates.setsid>();
         public static NativeDelegates.ioctl ioctl = NativeDelegates.GetProc<NativeDelegates.ioctl>();        
         public static NativeDelegates.execve execve = NativeDelegates.GetProc<NativeDelegates.execve>();
+        public static NativeDelegates.fork fork = NativeDelegates.GetProc<NativeDelegates.fork>();
+
 
         public static IntPtr StructToPtr(object obj)
         {

--- a/src/AvalonStudio.Terminals/Unix/UnixPsuedoTerminalProvider.cs
+++ b/src/AvalonStudio.Terminals/Unix/UnixPsuedoTerminalProvider.cs
@@ -34,23 +34,9 @@ namespace AvalonStudio.Terminals.Unix
             var attributes = Marshal.AllocHGlobal(1024);
             res = Native.posix_spawnattr_init(attributes);
 
-            var envVars = new List<string>();
-            var env = Environment.GetEnvironmentVariables();
-
-            foreach(var variable in env.Keys)
-            {
-                if(variable.ToString() != "TERM")
-                {
-                    envVars.Add($"{variable}={env[variable]}");
-                }
-            }
-
             int pid = Native.fork(); //Divided into two processes
 
-            if(pid == 0) RunBash("/data", name);
-
-            envVars.Add("TERM=xterm-256color");
-            envVars.Add(null);  
+            if(pid == 0) RunBash(initialDirectory, name);
 
             var stdin = Native.dup(fdm);
             var process = Process.GetProcessById((int)pid);

--- a/src/AvalonStudio.Terminals/Unix/UnixPsuedoTerminalProvider.cs
+++ b/src/AvalonStudio.Terminals/Unix/UnixPsuedoTerminalProvider.cs
@@ -36,14 +36,14 @@ namespace AvalonStudio.Terminals.Unix
 
             int pid = Native.fork(); //Divided into two processes
 
-            if(pid == 0) RunBash(initialDirectory, name);
+            if(pid == 0) RunBash(initialDirectory, name, arguments);
 
             var stdin = Native.dup(fdm);
             var process = Process.GetProcessById((int)pid);
             return new UnixPsuedoTerminal(process, fds, stdin, new FileStream(new SafeFileHandle(new IntPtr(stdin), true), FileAccess.Write), new FileStream(new SafeFileHandle(new IntPtr(fdm), true), FileAccess.Read));
         }
          
-        public static void RunBash(string path, string pt) {
+        public static void RunBash(string path, string pt, string[] arguments) {
 
             int slave = Native.open(pt, Native.O_RDWR);
  
@@ -69,6 +69,7 @@ namespace AvalonStudio.Terminals.Unix
 
             var argsArray = new List<string>();
             argsArray.Add("/bin/bash");
+            if(arguments.Length > 0 && !string.IsNullOrEmpty(arguments[0])) argsArray.AddRange(arguments);
             argsArray.Add(null);
 
             Native.execve(argsArray[0], argsArray.ToArray(), envVars.ToArray());


### PR DESCRIPTION
Update example to Avalonia 0.9.10
Update to netcore 3.1
Make AvalonStudio.TerminalEmulator work
Make terminal available on linux machines without dotnet installed

Check out my PR for VTNetcore.Avalonia too